### PR TITLE
Add missing f-string to warning.

### DIFF
--- a/ragelo/evaluators/retrieval_evaluators/base_retrieval_evaluator.py
+++ b/ragelo/evaluators/retrieval_evaluators/base_retrieval_evaluator.py
@@ -139,7 +139,7 @@ class BaseRetrievalEvaluator(BaseEvaluator):
         except ValueError as e:
             logger.warning(
                 f"Failed to PARSE answer for qid: {query.qid} "
-                "document id: {document.did}\n"
+                f"document id: {document.did}\n"
                 f"Raw answer: {raw_answer}"
             )
             exc = str(e)


### PR DESCRIPTION
A PR to fix a missing fstring in a ValueError warning log. This will show the document did of the warning