### PR TITLE
Add seed to base llm configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ evaluator = get_retrieval_evaluator(
     document_placeholder="d", # the placeholder for the document in the prompt
     llm_answer_format=response_format, # The format of the answer. Can be either `text`, if you expect plain text to be returned, `JSON` if the answer should be in JSON format, or `structured`, if you provide a Pydantic BaseModel as the response_schema.
     llm_response_schema=response_schema, # The response schema for the LLM. Required if the llm_answer_format is structured and recommended for JSON.
+    seed=42, # The seed for the LLM. Used to ensure we get the same answer for the same query and document pair.
 )
 
 result = evaluator.evaluate(

--- a/ragelo/llm_providers/ollama_client.py
+++ b/ragelo/llm_providers/ollama_client.py
@@ -55,6 +55,7 @@ class OllamaProvider(BaseLLMProvider):
                 temperature=self.config.temperature,
                 max_tokens=self.config.max_tokens,
                 response_format={"type": "json_object"},
+                seed=self.config.seed,
             )
         else:
             answers = await self.__ollama_client.chat.completions.create(
@@ -62,6 +63,7 @@ class OllamaProvider(BaseLLMProvider):
                 messages=prompt,  # type: ignore
                 temperature=self.config.temperature,
                 max_tokens=self.config.max_tokens,
+                seed=self.config.seed,
             )
         if not answers.choices or not answers.choices[0].message or not answers.choices[0].message.content:
             raise ValueError("Ollama did not return any completions.")

--- a/ragelo/llm_providers/openai_client.py
+++ b/ragelo/llm_providers/openai_client.py
@@ -54,6 +54,7 @@ class OpenAIProvider(BaseLLMProvider):
             "model": self.config.model,
             "temperature": self.config.temperature,
             "max_tokens": self.config.max_tokens,
+            "seed": self.config.seed,
         }
         call_fn: Callable
         if answer_format == AnswerFormat.STRUCTURED:

--- a/ragelo/types/configurations/llm_provider_configs.py
+++ b/ragelo/types/configurations/llm_provider_configs.py
@@ -7,6 +7,7 @@ class LLMProviderConfig(BaseModel):
     api_key: str | None
     temperature: float = 0.1
     max_tokens: int = 2048
+    seed: int | None = 42
 
 
 class OpenAIConfiguration(LLMProviderConfig):


### PR DESCRIPTION
Another QoL feature, supporting seeds in LLM calls to allow for reproducible outputs. This can be particularly helpful in managing the high variance of models as they can fluctuate between a relevance score of 0 and 1 for the same query-document pair.