### PR TITLE
Fix pydantic-related serialization issues

### DIFF
--- a/ragelo/types/experiment.py
+++ b/ragelo/types/experiment.py
@@ -374,14 +374,17 @@ class Experiment:
 
     def evaluate_retrieval(
         self,
+        relevance_key: str = "relevance",
         metrics: list[str] = ["Precision@10", "nDCG@10", "Judged@10"],
         relevance_threshold: int = 0,
     ) -> dict[str, dict[str, float]]:
         """
         Evaluate the retrieval performance of agents using specified metrics.
         Args:
+            relevance_key (str): The key in the answer object that contains an integer with the relevance of the
+                document.
             metrics (list[str]): A list of metrics to use. defaults to ["Precision@10", "nDCG@10", "Judged@10"].
-        relevance_threshold (int): The threshold above which a document is considered relevant (default is 0).
+            relevance_threshold (int): The threshold above which a document is considered relevant (default is 0).
         Returns:
             dict[str, dict[str, float]]: A dictionary where keys are agent names and values are dictionaries of scores.
         Raises:
@@ -393,7 +396,7 @@ class Experiment:
         - If the `rich` package is not installed, the results are printed using plain `print`.
 
         Example:
-        >>> results = evaluate_retrieval(metrics=["Precision@10", "nDCG@10"], relevance_threshold=1)
+        >>> results = evaluate_retrieval(relevance_key="relevance", metrics=["Precision@10", "nDCG@10"], relevance_threshold=1)
         >>> print(results)
         {
             "agent1": {
@@ -412,7 +415,10 @@ class Experiment:
             from ir_measures import parse_measure
         except ImportError:
             raise ImportError("ir_measures is not installed. Please install it with `pip install ir-measures`")
-        qrels = self.get_qrels(relevance_threshold=relevance_threshold)
+        qrels = self.get_qrels(
+            relevance_key=relevance_key,
+            relevance_threshold=relevance_threshold,
+        )
         runs = self.get_runs()
         measures = []
         for metric in metrics:
@@ -454,7 +460,7 @@ class Experiment:
 
     def get_qrels(
         self,
-        relevance_key: str | None = "answer",
+        relevance_key: str | None = "relevance",
         relevance_threshold: int = 0,
         output_path: str | None = None,
         output_format: Literal["trec", "json"] = "trec",
@@ -462,7 +468,7 @@ class Experiment:
         """
         Retrieve the qrels (query relevance judgments) for the queries.
         Args:
-            relevance_key (str | None): The key to use for determining relevance. Defaults to "answer".
+            relevance_key (str | None): The key to use for determining relevance. Defaults to "relevance".
             relevance_threshold (int): The threshold value for relevance. Defaults to 0.
         Returns:
             dict[str, dict[str, int]]: A dictionary where each key is a query ID and the value is another dictionary

--- a/ragelo/types/pydantic_models.py
+++ b/ragelo/types/pydantic_models.py
@@ -40,3 +40,10 @@ class BaseModel(PydanticBaseModel):
             return self.dict()  # type: ignore
         else:
             return super().model_dump(*args, **kwargs)  # type: ignore
+
+    @classmethod
+    def dump_pydantic(cls, pydantic_model: PydanticBaseModel):
+        if _PYDANTIC_MAJOR_VERSION == 1:
+            return pydantic_model.dict()  # type: ignore
+        else:
+            return pydantic_model.model_dump()  # type: ignore

--- a/ragelo/types/pydantic_models.py
+++ b/ragelo/types/pydantic_models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from importlib import metadata
+from typing import TypeAlias
 
 from pydantic import BaseModel as PydanticBaseModel
 
@@ -12,8 +13,10 @@ if _PYDANTIC_MAJOR_VERSION == 1:
     validator = root_validator(pre=True)  # type: ignore
     post_validator = root_validator(pre=False)  # type: ignore
     ValidationError = TypeError
+    SerializablePydanticBaseModel: TypeAlias = PydanticBaseModel
 else:
     from pydantic import (
+        SerializeAsAny,  # type: ignore
         ValidationError,  # type: ignore
         model_validator,  # type: ignore
     )
@@ -21,6 +24,7 @@ else:
     validator = model_validator(mode="before")  # type: ignore
     post_validator = model_validator(mode="after")  # type: ignore
     ValidationError = ValidationError
+    SerializablePydanticBaseModel: TypeAlias = SerializeAsAny[PydanticBaseModel]
 
 
 class BaseModel(PydanticBaseModel):

--- a/ragelo/types/results.py
+++ b/ragelo/types/results.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel as PydanticBaseModel
-
-from ragelo.types.pydantic_models import BaseModel, ValidationError, validator
+from ragelo.types.pydantic_models import (
+    BaseModel,
+    SerializablePydanticBaseModel,
+    ValidationError,
+    validator,
+)
 
 
 class EvaluatorResult(BaseModel):
@@ -20,7 +23,7 @@ class EvaluatorResult(BaseModel):
     qid: str
     agent: str | None = None
     raw_answer: str | None = None
-    answer: float | str | dict[str, Any] | PydanticBaseModel | None = None
+    answer: float | str | dict[str, Any] | SerializablePydanticBaseModel | None = None
     exception: str | None = None
 
     @validator


### PR DESCRIPTION
I encountered a few serialization issues regarding structured outputs with Pydantic.

1. For Pydantic ≥2, a model like `RetrievalEvaluatorResult` won't serialize its nested models for security reasons (see https://github.com/pydantic/pydantic/issues/7093). As a result, we need to explicitly mark it as serializable to avoid missing the parsed `answer` in the cached results so we can later load them from disk.

2. Additionally, there was a bug where pydantic models weren't being handled correctly when reading the qrels from disk (no check for `isinstance(answer, BaseModel)`,  only `isinstance(answer, dict)`).

3. Minor, but there was no argument for the correct relevance key in `evaluate_retrieval`, which depends on the user's configuration (ie what output schema they define).