### PR TITLE
Experiment loading fixes

### DIFF
--- a/ragelo/types/experiment.py
+++ b/ragelo/types/experiment.py
@@ -16,6 +16,7 @@ from typing import Any, Literal
 
 import rich
 from pydantic import BaseModel as PydanticBaseModel
+
 from ragelo.logger import logger
 from ragelo.types.evaluables import AgentAnswer, Document
 from ragelo.types.pydantic_models import _PYDANTIC_MAJOR_VERSION
@@ -156,7 +157,7 @@ class Experiment:
         else:
             self.queries = {}
         if queries_csv_path:
-            self.add_queries_from_csv(queries_csv_path, csv_query_id_col, csv_query_text_col)
+            self.add_queries_from_csv(queries_csv_path, csv_query_id_col, csv_query_text_col, exist_ok=True)
         if documents_csv_path:
             self.add_documents_from_csv(
                 documents_csv_path,
@@ -598,7 +599,7 @@ class Experiment:
         file_path: str,
         query_id_column: str | None = None,
         query_text_column: str = "query",
-        exists_ok: bool = False,
+        exist_ok: bool = False,
     ):
         if not os.path.isfile(file_path):
             raise FileNotFoundError(f"CSV file with queries {file_path} not found")
@@ -614,7 +615,7 @@ class Experiment:
             else:
                 qid = row.get(query_id_column, f"query_{idx}")
             if qid in read_queries or qid in self.queries:
-                if not exists_ok:
+                if not exist_ok:
                     logger.warning(f"Query with ID {qid} already read. Skipping")
                 continue
             query_text = row[query_text_column].strip()

--- a/ragelo/types/experiment.py
+++ b/ragelo/types/experiment.py
@@ -16,7 +16,6 @@ from typing import Any, Literal
 
 import rich
 from pydantic import BaseModel as PydanticBaseModel
-
 from ragelo.logger import logger
 from ragelo.types.evaluables import AgentAnswer, Document
 from ragelo.types.pydantic_models import _PYDANTIC_MAJOR_VERSION
@@ -149,6 +148,7 @@ class Experiment:
             else:
                 os.makedirs("ragelo_cache", exist_ok=True)
                 self.evaluations_cache_path = f"ragelo_cache/{self.experiment_name}_results.jsonl"
+            Path(self.evaluations_cache_path).parent.mkdir(parents=True, exist_ok=True)
             Path(self.evaluations_cache_path).touch()
 
         if self.save_path and os.path.isfile(self.save_path):

--- a/ragelo/types/experiment.py
+++ b/ragelo/types/experiment.py
@@ -598,6 +598,7 @@ class Experiment:
         file_path: str,
         query_id_column: str | None = None,
         query_text_column: str = "query",
+        exists_ok: bool = False,
     ):
         if not os.path.isfile(file_path):
             raise FileNotFoundError(f"CSV file with queries {file_path} not found")
@@ -613,7 +614,8 @@ class Experiment:
             else:
                 qid = row.get(query_id_column, f"query_{idx}")
             if qid in read_queries or qid in self.queries:
-                logger.warning(f"Query with ID {qid} already read. Skipping")
+                if not exists_ok:
+                    logger.warning(f"Query with ID {qid} already read. Skipping")
                 continue
             query_text = row[query_text_column].strip()
             metadata = {k: v for k, v in row.items() if k not in [query_id_column, query_text_column]}


### PR DESCRIPTION
This PR adds a couple of simple QoL improvements when loading an experiment. 
1. It assures that the `evaluations_cache_path` parents exists before creating it
2. If the output `.json` file already exists, but a queries `.csv` file is provided on the creation of the experiment, it will not warn for existing queries.