### PR TITLE
Bug fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Topic :: System :: Benchmark",
 ]
 dependencies = [
-    "openai>=1.10",
+    "openai>=1.78.0",
     "tenacity==9.0.0",
     "typer==0.12.5",
     "numpy>=1.24",

--- a/ragelo/evaluators/answer_evaluators/base_answer_evaluator.py
+++ b/ragelo/evaluators/answer_evaluators/base_answer_evaluator.py
@@ -301,11 +301,17 @@ class BaseAnswerEvaluator(BaseEvaluator):
                 continue
             if self.config.include_raw_documents and d.text is None:
                 continue
+            if d.evaluation is None:
+                annotation = None
+            elif self.config.use_raw_document_evaluation:
+                annotation = d.evaluation.raw_answer
+            else:
+                annotation = d.evaluation.answer
 
             formatters = {
                 "did": did,
                 "doc": d.text,
-                "annotation": d.evaluation.answer if d.evaluation else None,
+                "annotation": annotation,
             }
             documents.append(self.config.document_template.format(**formatters))
         if len(documents) == 0:

--- a/ragelo/evaluators/answer_evaluators/pairwise_evaluator.py
+++ b/ragelo/evaluators/answer_evaluators/pairwise_evaluator.py
@@ -149,7 +149,7 @@ and "C" for a tie.
         """Extracts the relevant part of an answer."""
         if isinstance(llm_response.parsed_answer, dict):
             answer = llm_response.parsed_answer["winner"]
-        elif isinstance(llm_response.parsed_answer, PydanticBaseModel):
+        elif isinstance(llm_response.parsed_answer, PairWiseAnswerAnswerFormat):
             answer = llm_response.parsed_answer.winner  # type: ignore
         else:
             answer = llm_response.parsed_answer

--- a/ragelo/evaluators/answer_evaluators/pairwise_evaluator.py
+++ b/ragelo/evaluators/answer_evaluators/pairwise_evaluator.py
@@ -96,7 +96,8 @@ and "C" for a tie.
         if config.prompt:
             self.prompt = config.prompt
         if config.llm_answer_format == AnswerFormat.STRUCTURED:
-            self.config.llm_response_schema = PairWiseAnswerAnswerFormat
+            if not config.llm_response_schema:
+                self.config.llm_response_schema = PairWiseAnswerAnswerFormat
         elif self.config.llm_answer_format != AnswerFormat.JSON:
             logger.warning("We are using a PairwiseAnswerEvaluator config. Forcing the LLM answer format to JSON.")
             self.config.llm_answer_format = AnswerFormat.JSON
@@ -148,8 +149,8 @@ and "C" for a tie.
         """Extracts the relevant part of an answer."""
         if isinstance(llm_response.parsed_answer, dict):
             answer = llm_response.parsed_answer["winner"]
-        elif isinstance(llm_response.parsed_answer, PairWiseAnswerAnswerFormat):
-            answer = llm_response.parsed_answer.winner
+        elif isinstance(llm_response.parsed_answer, PydanticBaseModel):
+            answer = llm_response.parsed_answer.winner  # type: ignore
         else:
             answer = llm_response.parsed_answer
         return LLMResponseType(

--- a/ragelo/evaluators/retrieval_evaluators/domain_expert_evaluator.py
+++ b/ragelo/evaluators/retrieval_evaluators/domain_expert_evaluator.py
@@ -177,7 +177,7 @@ document given the particular query. The score meaning is as follows:
             exc = "The LLM did not return a dictionary with a 'score' key"
             answer = None
         else:
-            answer = score_answer.parsed_answer["score"]
+            answer = float(score_answer.parsed_answer["score"])
         return RetrievalEvaluatorResult(
             qid=query.qid,
             did=document.did,

--- a/ragelo/types/configurations/answer_evaluator_configs.py
+++ b/ragelo/types/configurations/answer_evaluator_configs.py
@@ -47,6 +47,10 @@ class BaseAnswerEvaluatorConfig(BaseEvaluatorConfig):
             "By default, all documents are included."
         ),
     )
+    use_raw_document_evaluation: bool = Field(
+        default=False,
+        description="Whether or not to use the raw document evaluation when templating documents in the prompt",
+    )
 
 
 class PairwiseEvaluatorConfig(BaseAnswerEvaluatorConfig):
@@ -71,16 +75,13 @@ class PairwiseEvaluatorConfig(BaseAnswerEvaluatorConfig):
     )
     prompt: str | None = Field(
         default=None,
-        description="Prompt to use for the evaluator. If not provided, a default prompt will be used",
+        description="Prompt to use for the evaluator.",
     )
     factors: str = Field(
         default=(
-            "the correctness, helpfulness, completeness, accuracy, depth, and " "level of detail of their responses"
+            "the correctness, helpfulness, completeness, accuracy, depth, and level of detail of their responses"
         ),
-        description=(
-            "A string containing the factors to be used when evaluating an answer. "
-            "If not provided, a default string will be used"
-        ),
+        description=("A string containing the factors to be used when evaluating an answer. "),
     )
     llm_answer_format: AnswerFormat = Field(
         default=AnswerFormat.JSON,

--- a/ragelo/types/experiment.py
+++ b/ragelo/types/experiment.py
@@ -220,10 +220,10 @@ class Experiment:
         else:
             query_obj = Query(qid=query_id, query=query, metadata=metadata)
         if query_id in self.queries and not force:
-            warnings.warn(f"Query {query_id} already exists. Use force=True to overwrite")
+            logger.warning(f'Query with ID "{query_id}" already exists. Use force=True to overwrite')
             return query_id
         if query_id in self.queries and force:
-            logger.info(f"Query {query_id} already exists, but force was set to True. Overwriting.")
+            logger.info(f'Query with ID "{query_id}" already exists, but force was set to True. Overwriting.')
         self.queries[query_id] = query_obj
         return query_id
 

--- a/ragelo/types/query.py
+++ b/ragelo/types/query.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import warnings
 from collections.abc import Iterator
 from typing import Any, overload
 
@@ -116,7 +115,7 @@ class Query(BaseModel):
         answer = self.answers.get(agent, answer)
         if answer.agent in self.answers and not force:
             if not exist_ok:
-                warnings.warn(f"Answer from agent {answer.agent} already exists in query {self.qid}")
+                logger.warning(f"Answer from agent {answer.agent} already exists in query {self.qid}")
             return
         self.answers[agent] = answer
 
@@ -253,6 +252,8 @@ class Query(BaseModel):
                 answer = BaseModel.dump_pydantic(answer)
             if isinstance(answer, int):
                 relevance = answer
+            if isinstance(answer, float):
+                relevance = int(answer)
             elif isinstance(answer, str):
                 try:
                     relevance = int(answer)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock
 import pytest
 from openai import AsyncOpenAI
 from openai.resources.beta import AsyncBeta
-from openai.resources.beta.chat import AsyncChat
+from openai.resources.chat import AsyncChat
 from openai.types.chat.chat_completion import ChatCompletion, Choice
 from openai.types.chat.chat_completion_message import ChatCompletionMessage
 from openai.types.chat.parsed_chat_completion import (

--- a/tests/unit/test_experiment.py
+++ b/tests/unit/test_experiment.py
@@ -44,8 +44,7 @@ class TestExperiment:
         assert empty_experiment[qid2].query == "Test query 2"
 
         # Test force parameter
-        with pytest.warns(UserWarning):
-            empty_experiment.add_query("New query", qid, force=False)
+        empty_experiment.add_query("New query", qid, force=False)
         empty_experiment.add_query("Forced query", qid, force=True)
         assert empty_experiment[qid].query == "Forced query"
 


### PR DESCRIPTION
A bunch of small fixes and QoL improvements:

- Small fixes to logging
- Added option to use the raw document evaluation (e.g., the reasoning) when building the answer evaluation prompts
- Fixed an issue where a BaseModel llm_response_schema was not being properly set on PairwiseAnswerEvaluator
- Ensures that the retrieval DomainExpertEvaluator's answer is always a float.