### PR TITLE
feat: add LiteLLM as AI gateway provider

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
 [project.optional-dependencies]
 eval = ["ir-measures>=0.3.4"]
 instructor = ["instructor>=1.0.0"]
+litellm = ["litellm>=1.80.0,<1.87"]
 
 [dependency-groups]
 dev = [

--- a/ragelo/llm_providers/__init__.py
+++ b/ragelo/llm_providers/__init__.py
@@ -1,11 +1,13 @@
 from ragelo.llm_providers.base_llm_provider import BaseLLMProvider, LLMProviderFactory, get_llm_provider
 from ragelo.llm_providers.instructor_client import InstructorProvider
+from ragelo.llm_providers.litellm_client import LiteLLMProvider
 from ragelo.llm_providers.ollama_client import OllamaProvider
 from ragelo.llm_providers.openai_client import OpenAIProvider
 
 __all__ = [
     "BaseLLMProvider",
     "InstructorProvider",
+    "LiteLLMProvider",
     "LLMProviderFactory",
     "OllamaProvider",
     "OpenAIProvider",

--- a/ragelo/llm_providers/litellm_client.py
+++ b/ragelo/llm_providers/litellm_client.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, TypeVar
+
+from pydantic import BaseModel, ValidationError
+from tenacity import before_sleep_log, retry, retry_if_exception, stop_after_attempt, wait_random_exponential
+
+from ragelo.llm_providers.base_llm_provider import BaseLLMProvider, LLMProviderFactory
+from ragelo.types import LLMInputPrompt, LLMResponseType
+from ragelo.types.configurations import LiteLLMConfiguration
+from ragelo.types.types import LLMProviderTypes
+
+logger = logging.getLogger(__name__)
+
+T_Schema = TypeVar("T_Schema", bound=BaseModel)
+
+
+def _is_transient_error(exc: BaseException) -> bool:
+    qualname = f"{type(exc).__module__}.{type(exc).__qualname__}"
+    return qualname in {
+        "litellm.exceptions.RateLimitError",
+        "litellm.exceptions.Timeout",
+        "litellm.exceptions.APIConnectionError",
+        "litellm.exceptions.InternalServerError",
+        "litellm.exceptions.ServiceUnavailableError",
+    }
+
+
+@LLMProviderFactory.register(LLMProviderTypes.LITELLM)
+class LiteLLMProvider(BaseLLMProvider):
+    """LLM provider backed by LiteLLM, supporting 100+ providers through a unified interface.
+
+    Uses provider-prefixed model strings (e.g. ``openai/gpt-4o``,
+    ``anthropic/claude-sonnet-4-6``, ``groq/llama-3.3-70b-versatile``).
+    API keys are read from environment variables automatically by LiteLLM.
+
+    Requires ``pip install 'ragelo[litellm]'``.
+    """
+
+    config: LiteLLMConfiguration
+    api_key_env_var: str = ""
+
+    def __init__(self, config: LiteLLMConfiguration) -> None:
+        try:
+            import litellm  # noqa: F401
+        except ImportError:
+            raise ImportError("litellm is not installed. Install it with: pip install 'ragelo[litellm]'")
+        super().__init__(config)
+
+    @retry(
+        retry=retry_if_exception(_is_transient_error),
+        wait=wait_random_exponential(min=1, max=120),
+        stop=stop_after_attempt(3),
+        before_sleep=before_sleep_log(logger=logger, log_level=logging.INFO),
+        reraise=True,
+    )
+    async def call_async(self, input: LLMInputPrompt, response_schema: type[T_Schema]) -> LLMResponseType[T_Schema]:
+        """Calls the LLM via LiteLLM asynchronously.
+
+        Args:
+            input: A LLMInputPrompt object containing the system prompt, user message, or a list of messages.
+            response_schema: The Pydantic schema the LLM should fill in.
+
+        Returns:
+            LLMResponseType with raw_answer (str) and parsed_answer (instance of response_schema).
+        """
+        import litellm
+
+        messages: list[dict[str, str]] = []
+        if input.messages:
+            messages = input.messages
+        else:
+            if input.system_prompt:
+                messages.append({"role": "system", "content": input.system_prompt})
+            if input.user_message:
+                messages.append({"role": "user", "content": input.user_message})
+        if not messages:
+            raise ValueError("No input provided")
+
+        if isinstance(response_schema, type) and issubclass(response_schema, BaseModel):
+            schema_dict = response_schema.model_json_schema()
+        else:
+            schema_dict = response_schema  # type: ignore
+
+        schema = json.dumps(schema_dict, indent=4)
+        messages[-1]["content"] += (
+            f"\n\nYour output should be a JSON string that STRICTLY adheres to the following schema:\n{schema}"
+        )
+
+        call_kwargs: dict[str, Any] = {
+            "model": self.config.model,
+            "messages": messages,
+            "temperature": self.config.temperature,
+            "max_tokens": self.config.max_tokens,
+            "response_format": {"type": "json_object"},
+            "drop_params": True,
+        }
+        if self.config.api_key:
+            call_kwargs["api_key"] = self.config.api_key.get_secret_value()
+        if self.config.api_base:
+            call_kwargs["api_base"] = self.config.api_base
+
+        response = await litellm.acompletion(**call_kwargs)
+
+        if not response.choices or not response.choices[0].message or not response.choices[0].message.content:
+            raise ValueError("LiteLLM did not return any completions.")
+
+        raw_answer = response.choices[0].message.content
+        try:
+            parsed_answer = response_schema.model_validate_json(raw_answer)
+        except ValidationError as e:
+            raise ValueError(
+                f"Failed to parse raw JSON answer {raw_answer} into the response schema {response_schema}: {e}"
+            ) from e
+
+        return LLMResponseType(
+            raw_answer=raw_answer,
+            parsed_answer=parsed_answer,
+        )

--- a/ragelo/types/configurations/__init__.py
+++ b/ragelo/types/configurations/__init__.py
@@ -13,6 +13,7 @@ from ragelo.types.configurations.base_configs import BaseConfig, BaseEvaluatorCo
 from ragelo.types.configurations.cli_configs import CLIConfig
 from ragelo.types.configurations.llm_provider_configs import (
     InstructorConfiguration,
+    LiteLLMConfiguration,
     LLMProviderConfig,
     OllamaConfiguration,
     OpenAIConfiguration,
@@ -34,6 +35,7 @@ __all__ = [
     "OpenAIConfiguration",
     "OllamaConfiguration",
     "InstructorConfiguration",
+    "LiteLLMConfiguration",
     "AgentRankerConfig",
     "EloAgentRankerConfig",
     "BaseAnswerEvaluatorConfig",

--- a/ragelo/types/configurations/llm_provider_configs.py
+++ b/ragelo/types/configurations/llm_provider_configs.py
@@ -32,3 +32,9 @@ class InstructorConfiguration(LLMProviderConfig):
     use_cache: bool = True
     cache_size: int = 1000
     model_kwargs: dict[str, str] = {}
+
+
+class LiteLLMConfiguration(LLMProviderConfig):
+    model: str
+    api_key: SecretStr | None = None
+    api_base: str | None = None

--- a/ragelo/types/types.py
+++ b/ragelo/types/types.py
@@ -28,6 +28,7 @@ class LLMProviderTypes(StrEnum):
     OPENAI = "openai"
     OLLAMA = "ollama"
     INSTRUCTOR = "instructor"
+    LITELLM = "litellm"
 
 
 class AnswerEvaluatorTypes(StrEnum):

--- a/tests/unit/test_litellm_provider.py
+++ b/tests/unit/test_litellm_provider.py
@@ -1,0 +1,328 @@
+import json
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import SecretStr
+from tenacity import RetryError
+
+from ragelo.types.configurations import LiteLLMConfiguration
+from ragelo.types.formats import LLMInputPrompt, LLMResponseType
+from ragelo.types.results import PairwiseEvaluationAnswer, RetrievalEvaluationAnswer
+
+# Stub litellm before importing the provider
+_fake_litellm = types.ModuleType("litellm")
+_fake_exceptions = types.ModuleType("litellm.exceptions")
+
+
+class _FakeAuthenticationError(Exception):
+    pass
+
+
+class _FakeNotFoundError(Exception):
+    pass
+
+
+class _FakeRateLimitError(Exception):
+    pass
+
+
+class _FakeTimeout(Exception):
+    pass
+
+
+class _FakeBadRequestError(Exception):
+    pass
+
+
+_fake_exceptions.AuthenticationError = _FakeAuthenticationError
+_fake_exceptions.NotFoundError = _FakeNotFoundError
+_fake_exceptions.RateLimitError = _FakeRateLimitError
+_fake_exceptions.Timeout = _FakeTimeout
+_fake_exceptions.BadRequestError = _FakeBadRequestError
+_fake_exceptions.APIConnectionError = type("APIConnectionError", (Exception,), {"__module__": "litellm.exceptions"})
+_fake_exceptions.InternalServerError = type("InternalServerError", (Exception,), {"__module__": "litellm.exceptions"})
+_fake_exceptions.ServiceUnavailableError = type("ServiceUnavailableError", (Exception,), {"__module__": "litellm.exceptions"})
+
+_FakeRateLimitError.__module__ = "litellm.exceptions"
+_FakeRateLimitError.__qualname__ = "RateLimitError"
+_FakeTimeout.__module__ = "litellm.exceptions"
+_FakeTimeout.__qualname__ = "Timeout"
+
+_fake_litellm.exceptions = _fake_exceptions
+_fake_litellm.acompletion = AsyncMock()
+sys.modules["litellm"] = _fake_litellm
+sys.modules["litellm.exceptions"] = _fake_exceptions
+
+
+def _make_response(content: str):
+    msg = MagicMock()
+    msg.content = content
+    choice = MagicMock()
+    choice.message = msg
+    resp = MagicMock()
+    resp.choices = [choice]
+    return resp
+
+
+@pytest.fixture(autouse=True)
+def reset_litellm_mock():
+    _fake_litellm.acompletion.reset_mock()
+    _fake_litellm.acompletion.side_effect = None
+    retrieval_json = json.dumps({"reasoning": "Highly relevant", "score": 2})
+    _fake_litellm.acompletion.return_value = _make_response(retrieval_json)
+    yield
+
+
+@pytest.fixture
+def litellm_config():
+    return LiteLLMConfiguration(
+        model="anthropic/claude-sonnet-4-6",
+        api_key=SecretStr("sk-test-123"),
+        temperature=0.1,
+        max_tokens=4096,
+    )
+
+
+@pytest.fixture
+def litellm_config_no_key():
+    return LiteLLMConfiguration(model="openai/gpt-4o-mini")
+
+
+@pytest.fixture
+def litellm_provider(litellm_config):
+    from ragelo.llm_providers.litellm_client import LiteLLMProvider
+    return LiteLLMProvider(config=litellm_config)
+
+
+@pytest.fixture
+def litellm_provider_no_key(litellm_config_no_key):
+    from ragelo.llm_providers.litellm_client import LiteLLMProvider
+    return LiteLLMProvider(config=litellm_config_no_key)
+
+
+class TestLiteLLMProvider:
+    """Tests for LiteLLMProvider covering structured output, error handling, and edge cases."""
+
+    def test_retrieval_evaluation(self, litellm_provider):
+        result = litellm_provider(
+            LLMInputPrompt(user_message="Evaluate this document."),
+            response_schema=RetrievalEvaluationAnswer,
+        )
+        assert isinstance(result, LLMResponseType)
+        assert isinstance(result.parsed_answer, RetrievalEvaluationAnswer)
+        assert result.parsed_answer.reasoning == "Highly relevant"
+        assert result.parsed_answer.score == 2
+
+    def test_pairwise_evaluation(self, litellm_provider):
+        pairwise_json = json.dumps({
+            "answer_a_analysis": "A is good",
+            "answer_b_analysis": "B is less detailed",
+            "comparison_reasoning": "A is better",
+            "winner": "A",
+        })
+        _fake_litellm.acompletion.return_value = _make_response(pairwise_json)
+
+        result = litellm_provider(
+            LLMInputPrompt(user_message="Compare these two answers."),
+            response_schema=PairwiseEvaluationAnswer,
+        )
+        assert isinstance(result.parsed_answer, PairwiseEvaluationAnswer)
+        assert result.parsed_answer.winner == "A"
+
+    def test_drop_params_always_true(self, litellm_provider):
+        litellm_provider(
+            LLMInputPrompt(user_message="Test"),
+            response_schema=RetrievalEvaluationAnswer,
+        )
+        call_kwargs = _fake_litellm.acompletion.call_args[1]
+        assert call_kwargs["drop_params"] is True
+
+    def test_model_forwarded(self, litellm_provider):
+        litellm_provider(
+            LLMInputPrompt(user_message="Test"),
+            response_schema=RetrievalEvaluationAnswer,
+        )
+        call_kwargs = _fake_litellm.acompletion.call_args[1]
+        assert call_kwargs["model"] == "anthropic/claude-sonnet-4-6"
+
+    def test_provider_prefixed_model_string(self, litellm_provider):
+        litellm_provider(
+            LLMInputPrompt(user_message="Test"),
+            response_schema=RetrievalEvaluationAnswer,
+        )
+        call_kwargs = _fake_litellm.acompletion.call_args[1]
+        assert "/" in call_kwargs["model"]
+
+    def test_api_key_forwarded(self, litellm_provider):
+        litellm_provider(
+            LLMInputPrompt(user_message="Test"),
+            response_schema=RetrievalEvaluationAnswer,
+        )
+        call_kwargs = _fake_litellm.acompletion.call_args[1]
+        assert call_kwargs["api_key"] == "sk-test-123"
+
+    def test_api_key_omitted_when_none(self, litellm_provider_no_key):
+        litellm_provider_no_key(
+            LLMInputPrompt(user_message="Test"),
+            response_schema=RetrievalEvaluationAnswer,
+        )
+        call_kwargs = _fake_litellm.acompletion.call_args[1]
+        assert "api_key" not in call_kwargs
+
+    def test_temperature_forwarded(self, litellm_provider):
+        litellm_provider(
+            LLMInputPrompt(user_message="Test"),
+            response_schema=RetrievalEvaluationAnswer,
+        )
+        call_kwargs = _fake_litellm.acompletion.call_args[1]
+        assert call_kwargs["temperature"] == 0.1
+
+    def test_system_and_user_prompt(self, litellm_provider):
+        litellm_provider(
+            LLMInputPrompt(system_prompt="You are an evaluator.", user_message="Evaluate this."),
+            response_schema=RetrievalEvaluationAnswer,
+        )
+        call_kwargs = _fake_litellm.acompletion.call_args[1]
+        messages = call_kwargs["messages"]
+        assert messages[0] == {"role": "system", "content": "You are an evaluator."}
+        assert "Evaluate this." in messages[1]["content"]
+
+    def test_messages_list_input(self, litellm_provider):
+        messages = [
+            {"role": "system", "content": "You are an evaluator."},
+            {"role": "user", "content": "Evaluate this."},
+        ]
+        litellm_provider(
+            LLMInputPrompt(messages=messages),
+            response_schema=RetrievalEvaluationAnswer,
+        )
+        call_kwargs = _fake_litellm.acompletion.call_args[1]
+        assert call_kwargs["messages"][0]["role"] == "system"
+
+    def test_json_schema_appended_to_prompt(self, litellm_provider):
+        litellm_provider(
+            LLMInputPrompt(user_message="Evaluate this."),
+            response_schema=RetrievalEvaluationAnswer,
+        )
+        call_kwargs = _fake_litellm.acompletion.call_args[1]
+        last_msg = call_kwargs["messages"][-1]["content"]
+        assert "schema" in last_msg.lower()
+        assert "JSON" in last_msg
+
+    def test_response_format_json_object(self, litellm_provider):
+        litellm_provider(
+            LLMInputPrompt(user_message="Test"),
+            response_schema=RetrievalEvaluationAnswer,
+        )
+        call_kwargs = _fake_litellm.acompletion.call_args[1]
+        assert call_kwargs["response_format"] == {"type": "json_object"}
+
+
+class TestLiteLLMProviderErrors:
+    """Tests for error handling with litellm-specific exceptions."""
+
+    def test_auth_error_not_retried(self, litellm_provider):
+        _fake_litellm.acompletion.side_effect = _FakeAuthenticationError("Invalid API key")
+        with pytest.raises(_FakeAuthenticationError, match="Invalid API key"):
+            litellm_provider(
+                LLMInputPrompt(user_message="Test"),
+                response_schema=RetrievalEvaluationAnswer,
+            )
+        assert _fake_litellm.acompletion.call_count == 1
+
+    def test_not_found_error_not_retried(self, litellm_provider):
+        _fake_litellm.acompletion.side_effect = _FakeNotFoundError("Model not found")
+        with pytest.raises(_FakeNotFoundError, match="Model not found"):
+            litellm_provider(
+                LLMInputPrompt(user_message="Test"),
+                response_schema=RetrievalEvaluationAnswer,
+            )
+        assert _fake_litellm.acompletion.call_count == 1
+
+    def test_bad_request_error_not_retried(self, litellm_provider):
+        _fake_litellm.acompletion.side_effect = _FakeBadRequestError("context_length_exceeded")
+        with pytest.raises(_FakeBadRequestError):
+            litellm_provider(
+                LLMInputPrompt(user_message="Test"),
+                response_schema=RetrievalEvaluationAnswer,
+            )
+        assert _fake_litellm.acompletion.call_count == 1
+
+    def test_rate_limit_retried(self, litellm_provider):
+        _fake_litellm.acompletion.side_effect = _fake_exceptions.RateLimitError("429")
+        with pytest.raises(_fake_exceptions.RateLimitError):
+            litellm_provider(
+                LLMInputPrompt(user_message="Test"),
+                response_schema=RetrievalEvaluationAnswer,
+            )
+        assert _fake_litellm.acompletion.call_count == 3
+
+    def test_timeout_retried(self, litellm_provider):
+        _fake_litellm.acompletion.side_effect = _fake_exceptions.Timeout("timed out")
+        with pytest.raises(_fake_exceptions.Timeout):
+            litellm_provider(
+                LLMInputPrompt(user_message="Test"),
+                response_schema=RetrievalEvaluationAnswer,
+            )
+        assert _fake_litellm.acompletion.call_count == 3
+
+    def test_empty_response_raises(self, litellm_provider):
+        empty_resp = MagicMock()
+        empty_resp.choices = []
+        _fake_litellm.acompletion.return_value = empty_resp
+        with pytest.raises((RetryError, ValueError)):
+            litellm_provider(
+                LLMInputPrompt(user_message="Test"),
+                response_schema=RetrievalEvaluationAnswer,
+            )
+
+    def test_null_content_raises(self, litellm_provider):
+        _fake_litellm.acompletion.return_value = _make_response(None)
+        _fake_litellm.acompletion.return_value.choices[0].message.content = None
+        with pytest.raises((RetryError, ValueError)):
+            litellm_provider(
+                LLMInputPrompt(user_message="Test"),
+                response_schema=RetrievalEvaluationAnswer,
+            )
+
+    def test_invalid_json_raises(self, litellm_provider):
+        _fake_litellm.acompletion.return_value = _make_response("not valid json")
+        with pytest.raises((RetryError, ValueError)):
+            litellm_provider(
+                LLMInputPrompt(user_message="Test"),
+                response_schema=RetrievalEvaluationAnswer,
+            )
+
+    def test_missing_required_field_raises(self, litellm_provider):
+        _fake_litellm.acompletion.return_value = _make_response(json.dumps({"reasoning": "ok"}))
+        with pytest.raises((RetryError, ValueError)):
+            litellm_provider(
+                LLMInputPrompt(user_message="Test"),
+                response_schema=RetrievalEvaluationAnswer,
+            )
+
+
+class TestLiteLLMProviderFactory:
+    """Tests for factory registration and creation."""
+
+    def test_factory_creates_litellm_provider(self):
+        from ragelo.llm_providers import get_llm_provider
+        from ragelo.llm_providers.litellm_client import LiteLLMProvider
+
+        provider = get_llm_provider("litellm", model="openai/gpt-4o-mini")
+        assert isinstance(provider, LiteLLMProvider)
+        assert provider.config.model == "openai/gpt-4o-mini"
+
+    def test_factory_with_api_key(self):
+        from ragelo.llm_providers import get_llm_provider
+
+        provider = get_llm_provider("litellm", model="anthropic/claude-haiku-4-5", api_key="sk-test")
+        assert provider.config.api_key.get_secret_value() == "sk-test"
+
+    def test_factory_with_api_base(self):
+        from ragelo.llm_providers import get_llm_provider
+
+        provider = get_llm_provider("litellm", model="openai/gpt-4o", api_base="http://localhost:4000")
+        assert provider.config.api_base == "http://localhost:4000"


### PR DESCRIPTION


## Summary
- Adds LiteLLM as a new LLM provider, giving RAGElo users access to 100+ LLM providers (Anthropic, Google, Groq, Together AI, AWS Bedrock, Azure, Mistral, etc.) through the existing factory interface
- Follows the same pattern as the Ollama and Instructor providers

## Prior art

## Motivation
RAGElo currently supports OpenAI (Responses API), Ollama, and Instructor. LiteLLM provides a single `litellm.acompletion()` call that routes to 100+ providers using provider-prefixed model strings (e.g. `openai/gpt-4o`, `anthropic/claude-sonnet-4-6`). This is useful when users want direct completion access without Instructor's overhead, or need LiteLLM-specific features like proxy routing and automatic fallbacks.

## Changes
- `ragelo/llm_providers/litellm_client.py` - new `LiteLLMProvider(BaseLLMProvider)` using `litellm.acompletion()` with `drop_params=True` and transient-only retry (rate limit, timeout, connection errors retried; auth/not-found/bad-request not retried)
- `ragelo/llm_providers/__init__.py` - registered `LiteLLMProvider`
- `ragelo/types/types.py` - added `LITELLM = "litellm"` to `LLMProviderTypes` enum
- `ragelo/types/configurations/llm_provider_configs.py` - added `LiteLLMConfiguration`
- `ragelo/types/configurations/__init__.py` - exported `LiteLLMConfiguration`
- `pyproject.toml` - added `litellm>=1.80.0,<1.87` as optional dependency
- `tests/unit/test_litellm_provider.py` - 24 unit tests

## Key design decisions
- **Follows Ollama pattern** - uses `chat.completions`-compatible response format (not the Responses API), JSON schema appended to prompt, `response_format=json_object`
- **`drop_params=True` always set** - silently drops per-provider-unsupported kwargs. Prevents cross-provider errors when users switch models
- **Transient-only retry** - only retries `RateLimitError`, `Timeout`, `APIConnectionError`, `InternalServerError`, `ServiceUnavailableError`. Auth errors, model-not-found, bad requests fail immediately (1 call, no retry)
- **Optional dependency** - `pip install 'ragelo[litellm]'`, import guard raises clear error if not installed
- **API key optional** - when not set, LiteLLM reads from provider env vars (`ANTHROPIC_API_KEY`, etc.)

## Tests

**1. Unit tests (24 passed):**
```
TestLiteLLMProvider::test_retrieval_evaluation PASSED
TestLiteLLMProvider::test_pairwise_evaluation PASSED
TestLiteLLMProvider::test_drop_params_always_true PASSED
TestLiteLLMProvider::test_model_forwarded PASSED
TestLiteLLMProvider::test_provider_prefixed_model_string PASSED
TestLiteLLMProvider::test_api_key_forwarded PASSED
TestLiteLLMProvider::test_api_key_omitted_when_none PASSED
TestLiteLLMProvider::test_temperature_forwarded PASSED
TestLiteLLMProvider::test_system_and_user_prompt PASSED
TestLiteLLMProvider::test_messages_list_input PASSED
TestLiteLLMProvider::test_json_schema_appended_to_prompt PASSED
TestLiteLLMProvider::test_response_format_json_object PASSED
TestLiteLLMProviderErrors::test_auth_error_not_retried PASSED
TestLiteLLMProviderErrors::test_not_found_error_not_retried PASSED
TestLiteLLMProviderErrors::test_bad_request_error_not_retried PASSED
TestLiteLLMProviderErrors::test_rate_limit_retried PASSED
TestLiteLLMProviderErrors::test_timeout_retried PASSED
TestLiteLLMProviderErrors::test_empty_response_raises PASSED
TestLiteLLMProviderErrors::test_null_content_raises PASSED
TestLiteLLMProviderErrors::test_invalid_json_raises PASSED
TestLiteLLMProviderErrors::test_missing_required_field_raises PASSED
TestLiteLLMProviderFactory::test_factory_creates_litellm_provider PASSED
TestLiteLLMProviderFactory::test_factory_with_api_key PASSED
TestLiteLLMProviderFactory::test_factory_with_api_base PASSED
======================== 24 passed in 5.43s
```

**Edge cases covered:**
- Auth error (invalid key) - not retried, 1 call
- Model not found - not retried, 1 call
- Bad request (context overflow) - not retried, 1 call
- Rate limit (429) - retried 3x, then re-raised
- Timeout - retried 3x, then re-raised
- Empty/null response - raises ValueError
- Invalid JSON response - raises ValueError
- Missing required schema fields - raises ValueError
- Factory creation with/without api_key/api_base

**2. Regression (full existing test suite unaffected):**
```
======================= 197 passed, 10 skipped in 13.09s =======================
```

**3. Live E2E against Azure AI Foundry (Anthropic Claude Sonnet 4.6):**
```python
provider = get_llm_provider('litellm', model='anthropic/claude-sonnet-4-6', ...)
result = provider(
    LLMInputPrompt(user_message='Is Paris the capital of France? Provide reasoning and score 2 if yes, 0 if no.'),
    response_schema=RetrievalEvaluationAnswer,
)
```
```
Type: LLMResponseType
Parsed: RetrievalEvaluationAnswer
Reasoning: Paris is indeed the capital of France...
Score: 2
LIVE E2E PASSED
```

## Risk / Compatibility
- Additive only, no existing provider code modified
- `litellm` is an optional dependency (`pip install 'ragelo[litellm]'`), base install unaffected
- Registered in the factory like all other providers

## Example usage

```python
from ragelo.llm_providers import get_llm_provider
from ragelo.types.formats import LLMInputPrompt
from ragelo.types.results import RetrievalEvaluationAnswer

# API keys from env vars (OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.)
provider = get_llm_provider("litellm", model="anthropic/claude-sonnet-4-6")

result = provider(
    LLMInputPrompt(
        system_prompt="You are a relevance evaluation expert.",
        user_message="Evaluate the relevance of this document to the query.",
    ),
    response_schema=RetrievalEvaluationAnswer,
)
print(result.parsed_answer.reasoning)
print(result.parsed_answer.score)
```

