### PR TITLE
Serve and export run files as retrievers

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,8 @@ The mapping key becomes the agent name. Documents are pooled by `did`, so a docu
 
 `compare_retrieval` pairs the runs on a fixed query set per metric (a query missing from a run counts as 0), reports per-query win/tie/loss counts, and computes a two-sided sign-flip permutation p-value over the per-query differences. Because of the zero-fill, its means can differ slightly from `evaluate_retrieval`, which averages only over the queries a run scored. The returned `RetrievalComparisonResult` carries `per_query_delta` for every metric, so the biggest wins and losses are one `sorted()` away.
 
+A run can also be extracted once and reused: `experiment.get_run_files(output_dir="runs/")` writes one JSON run file per system (ranked lists with text inline, the serialization of `RunFile`), and `FileRetriever.from_run_file(path)` serves one back as a retriever, so a saved baseline can be compared against a live system, or two saved runs against each other, without index access. When the two sides search different corpora and their ids would collide, wrap either in `NamespacedRetriever(retriever, "prefix")`.
+
 ### 🎮 Interactive Elo ranking
 
 Instead of running a full tournament, you can rank agents incrementally — run individual games or onboard a brand-new agent with minimal matches:

--- a/ragelo/__init__.py
+++ b/ragelo/__init__.py
@@ -6,7 +6,7 @@ from ragelo.evaluators.retrieval_evaluators import RetrievalEvaluatorFactory, ge
 from ragelo.generators import RubricGenerator, get_rubric_generator
 from ragelo.llm_providers.base_llm_provider import get_llm_provider
 from ragelo.logger import configure_logging
-from ragelo.retrievers import RetrievedDocument, Retriever
+from ragelo.retrievers import FileRetriever, NamespacedRetriever, RetrievedDocument, Retriever, RunFile
 from ragelo.types import AgentAnswer, Document, Experiment, Query
 
 __all__ = [
@@ -14,11 +14,14 @@ __all__ = [
     "AnswerEvaluatorFactory",
     "Document",
     "Experiment",
+    "FileRetriever",
+    "NamespacedRetriever",
     "Query",
     "RetrievalEvaluatorFactory",
     "RetrievedDocument",
     "Retriever",
     "RubricGenerator",
+    "RunFile",
     "configure_logging",
     "get_agent_ranker",
     "get_answer_evaluator",

--- a/ragelo/retrievers.py
+++ b/ragelo/retrievers.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Sequence
+from pathlib import Path
 from typing import Any, Protocol
 
 from pydantic import BaseModel
 
 from ragelo.types.query import Query
+
+logger = logging.getLogger(__name__)
 
 
 class RetrievedDocument(BaseModel):
@@ -29,3 +33,54 @@ class Retriever(Protocol):
     async def retrieve(self, query: Query, top_k: int) -> Sequence[RetrievedDocument]:
         """Returns the top_k documents for the query, best first."""
         ...
+
+
+class RunFile(BaseModel):
+    """One system's ranked lists with text inline, keyed by qid. Array order is the rank."""
+
+    retriever_name: str | None = None
+    top_k: int | None = None
+    runs: dict[str, list[RetrievedDocument]]
+
+
+class FileRetriever:
+    """Serves a pre-extracted run file as a Retriever.
+
+    Documents without text cannot be judged, so they are dropped at load and counted in
+    `skipped_without_text`.
+    """
+
+    def __init__(self, runs: dict[str, list[RetrievedDocument]], skipped_without_text: int = 0) -> None:
+        self.__runs = runs
+        self.skipped_without_text = skipped_without_text
+
+    @classmethod
+    def from_run_file(cls, path: str | Path) -> FileRetriever:
+        run_file = RunFile.model_validate_json(Path(path).read_text())
+        runs: dict[str, list[RetrievedDocument]] = {}
+        skipped = 0
+        for qid, documents in run_file.runs.items():
+            kept = [document for document in documents if document.text]
+            skipped += len(documents) - len(kept)
+            runs[qid] = kept
+        if skipped:
+            logger.warning(f"{path}: dropped {skipped} documents without text, which cannot be judged.")
+        return cls(runs, skipped)
+
+    async def retrieve(self, query: Query, top_k: int) -> list[RetrievedDocument]:
+        if query.qid not in self.__runs:
+            logger.warning(f"Run file has no entry for query {query.qid}. Do the qid schemes match?")
+            return []
+        return self.__runs[query.qid][:top_k]
+
+
+class NamespacedRetriever:
+    """Prefixes every did a retriever returns, so systems searching different corpora can pool."""
+
+    def __init__(self, retriever: Retriever, prefix: str) -> None:
+        self.__retriever = retriever
+        self.__prefix = prefix
+
+    async def retrieve(self, query: Query, top_k: int) -> list[RetrievedDocument]:
+        documents = await self.__retriever.retrieve(query, top_k)
+        return [document.model_copy(update={"did": f"{self.__prefix}::{document.did}"}) for document in documents]

--- a/ragelo/types/experiment.py
+++ b/ragelo/types/experiment.py
@@ -27,6 +27,7 @@ from ragelo.measures import (
     parse_measure,
 )
 from ragelo.presenters import render_evaluation, render_retrieval_comparison, render_retrieval_summary
+from ragelo.retrievers import RetrievedDocument, Retriever, RunFile
 from ragelo.types.answer_formats import SubtopicJudgment
 from ragelo.types.evaluables import AgentAnswer, Document, Evaluable
 from ragelo.types.evaluator_utils import resolve_evaluator_result_type
@@ -44,8 +45,6 @@ from ragelo.utils import call_async_fn, get_pbar
 
 if TYPE_CHECKING:
     from ir_measures import Qrel
-
-    from ragelo.retrievers import RetrievedDocument, Retriever
 
 logger = logging.getLogger(__name__)
 
@@ -766,6 +765,42 @@ class Experiment:
                     json.dump(runs_by_agent, f)
 
         return runs_by_agent
+
+    def get_run_files(
+        self,
+        agents: list[str] | None = None,
+        output_dir: str | Path | None = None,
+    ) -> dict[str, RunFile]:
+        """One reusable run file per agent, reconstructing each ranked list from the pooled documents.
+
+        A pooled document's metadata comes from whichever agent retrieved it first, so it rides
+        along for tracing rather than as the exporting agent's own record.
+        """
+        if agents is None:
+            agents = sorted({agent for query in self for agent in query.retrieval_systems})
+        run_files: dict[str, RunFile] = {}
+        for agent in agents:
+            runs: dict[str, list[RetrievedDocument]] = {}
+            for query in self:
+                scored = [
+                    (document, score)
+                    for document in query.retrieved_docs.values()
+                    for retrieved_by, score in document.retrieved_by.items()
+                    if retrieved_by == agent
+                ]
+                scored.sort(key=lambda pair: pair[1], reverse=True)
+                runs[query.qid] = [
+                    RetrievedDocument(did=document.did, text=document.text, score=score, metadata=document.metadata)
+                    for document, score in scored
+                ]
+            run_files[agent] = RunFile(retriever_name=agent, runs=runs)
+        if output_dir is not None:
+            output_dir = Path(output_dir)
+            output_dir.mkdir(parents=True, exist_ok=True)
+            for agent, run_file in run_files.items():
+                (output_dir / f"{agent}.json").write_text(run_file.model_dump_json(indent=2, exclude_none=True))
+            logger.info(f"Wrote {len(run_files)} run files to {output_dir}")
+        return run_files
 
     def save(self, output_path: str | Path | None = None) -> None:
         """

--- a/tests/unit/test_retrievers.py
+++ b/tests/unit/test_retrievers.py
@@ -1,0 +1,111 @@
+import asyncio
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from ragelo import Document, Experiment, FileRetriever, NamespacedRetriever, RunFile
+from ragelo.types.query import Query
+
+
+def _run_file(path, runs):
+    path.write_text(json.dumps({"retriever_name": "baseline", "runs": runs}))
+    return path
+
+
+class TestFileRetriever:
+    def test_serves_ranked_documents_and_honours_top_k(self, tmp_path):
+        path = _run_file(
+            tmp_path / "run.json",
+            {
+                "q1": [
+                    {"did": "d0", "text": "first", "score": 2.0},
+                    {"did": "d1", "text": "second", "score": 1.0},
+                ]
+            },
+        )
+        retriever = FileRetriever.from_run_file(path)
+
+        top1 = asyncio.run(retriever.retrieve(Query(qid="q1", query="q"), top_k=1))
+        assert [document.did for document in top1] == ["d0"]
+
+    def test_a_query_absent_from_the_file_returns_nothing_and_warns(self, tmp_path, caplog):
+        path = _run_file(tmp_path / "run.json", {"q1": [{"did": "d0", "text": "t"}]})
+        retriever = FileRetriever.from_run_file(path)
+
+        documents = asyncio.run(retriever.retrieve(Query(qid="missing", query="q"), top_k=10))
+
+        assert documents == []
+        assert "no entry for query missing" in caplog.text
+
+    def test_drops_textless_entries_and_counts_them(self, tmp_path):
+        path = _run_file(tmp_path / "run.json", {"q1": [{"did": "d0", "text": "kept"}, {"did": "d1", "text": ""}]})
+        retriever = FileRetriever.from_run_file(path)
+
+        documents = asyncio.run(retriever.retrieve(Query(qid="q1", query="q"), top_k=10))
+        assert [document.did for document in documents] == ["d0"]
+        assert retriever.skipped_without_text == 1
+
+    def test_a_malformed_run_file_raises_a_validation_error(self, tmp_path):
+        path = _run_file(tmp_path / "run.json", {"q1": [{"did": "d0"}]})
+        with pytest.raises(ValidationError):
+            FileRetriever.from_run_file(path)
+
+
+class TestNamespacedRetriever:
+    def test_prefixes_every_did_and_keeps_the_rest(self, tmp_path):
+        path = _run_file(tmp_path / "run.json", {"q1": [{"did": "d0", "text": "t", "score": 5.0}]})
+        retriever = NamespacedRetriever(FileRetriever.from_run_file(path), "baseline")
+
+        documents = asyncio.run(retriever.retrieve(Query(qid="q1", query="q"), top_k=10))
+
+        assert [(document.did, document.text, document.score) for document in documents] == [
+            ("baseline::d0", "t", 5.0)
+        ]
+
+
+class TestGetRunFiles:
+    def test_round_trips_a_pooled_experiment(self, tmp_path):
+        experiment = Experiment(experiment_name="t", save_on_disk=False)
+        experiment.add_query(Query(qid="q1", query="q"), should_save=False)
+        experiment.add_retrieved_doc(Document(qid="q1", did="d0", text="alpha"), score=0.9, agent="sys-a")
+        experiment.add_retrieved_doc(Document(qid="q1", did="d1", text="beta"), score=2.5, agent="sys-a")
+
+        run_files = experiment.get_run_files(output_dir=tmp_path)
+
+        dumped = RunFile.model_validate_json((tmp_path / "sys-a.json").read_text())
+        assert dumped == run_files["sys-a"]
+        assert [document.did for document in dumped.runs["q1"]] == ["d1", "d0"]
+
+        reloaded = FileRetriever.from_run_file(tmp_path / "sys-a.json")
+        documents = asyncio.run(reloaded.retrieve(Query(qid="q1", query="q"), top_k=10))
+        assert [(document.did, document.text, document.score) for document in documents] == [
+            ("d1", "beta", 2.5),
+            ("d0", "alpha", 0.9),
+        ]
+
+    def test_exports_only_the_requested_agents(self):
+        experiment = Experiment(experiment_name="t", save_on_disk=False)
+        experiment.add_query(Query(qid="q1", query="q"), should_save=False)
+        experiment.add_retrieved_doc(Document(qid="q1", did="d0", text="alpha"), score=1.0, agent="sys-a")
+        experiment.add_retrieved_doc(
+            Document(qid="q1", did="d0", text="alpha"), score=2.0, agent="sys-b", exist_ok=True
+        )
+
+        run_files = experiment.get_run_files(agents=["sys-b"])
+
+        assert list(run_files) == ["sys-b"]
+        assert [document.score for document in run_files["sys-b"].runs["q1"]] == [2.0]
+
+    def test_a_reloaded_run_pools_with_the_agent_that_produced_it(self, tmp_path):
+        source = Experiment(experiment_name="s", save_on_disk=False)
+        source.add_query(Query(qid="q1", query="q"), should_save=False)
+        source.add_retrieved_doc(Document(qid="q1", did="d0", text="alpha"), score=1.0, agent="sys-a")
+        source.get_run_files(output_dir=tmp_path)
+
+        target = Experiment(experiment_name="t", save_on_disk=False)
+        target.add_query(Query(qid="q1", query="q"), should_save=False)
+        target.run_retrievers({"sys-a": FileRetriever.from_run_file(tmp_path / "sys-a.json")}, top_k=10)
+
+        assert target["q1"].retrieved_docs["d0"].retrieved_by == {"sys-a": 1.0}
+        assert target["q1"].retrieved_docs["d0"].text == "alpha"


### PR DESCRIPTION
## Summary

Adds the run-file round trip the retriever comparison was missing: extract a system's results once, then compare against them offline, share them with someone lacking index access, or replay them as a baseline.

## Key changes

- **`RunFile`**: the canonical serialization of one system's ranked lists, text inline, keyed by qid, with array order as the rank. It is a pydantic model over `RetrievedDocument`, so the reader and writer share one schema and malformed files fail with real validation errors. No existing format could serve: the TREC importer carries no text and needs a separate corpus, `get_runs` exports ids and scores only, and the experiment save file is whole-experiment rather than per-system.
- **`FileRetriever.from_run_file(path)`** serves a run file through the `Retriever` protocol, making a frozen run just another retriever in `run_retrievers`: same pooling, same resume, same did/text collision guard. Entries without text are dropped and counted (`skipped_without_text`), since a document with no text cannot be judged; a requested qid with no entry in the file returns nothing and warns, so a mismatched qid scheme surfaces as a log line instead of a silent all-zeros run.
- **`Experiment.get_run_files(agents=None, output_dir=None)`** exports each pooled agent's run, reconstructed by that agent's own scores. A pooled document's metadata comes from whichever agent retrieved it first, so it rides along for tracing rather than as the exporting agent's own record.
- **`NamespacedRetriever(retriever, prefix)`** prefixes every did a retriever returns. The did collision that motivates it is not file-specific (two live retrievers over different indexes hit the same guard), so it is a wrapper composable over any retriever rather than a file-format field.

## Docs and tests

The README A/B section gains the extract-once/compare-many paragraph. Tests cover ranked serving with top_k, the missing-qid warning, textless-entry dropping, malformed-file validation, did prefixing, agent-filtered export, and a dump/reload/re-pool round trip.
